### PR TITLE
fix(pvo-1177): reduce liveodds recovery window

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -25,7 +25,7 @@ var producers = []struct {
 	scope          string
 	recoveryWindow int // in minutes
 }{
-	{id: 1, name: "LO", description: "Live Odds", code: "liveodds", scope: "live", recoveryWindow: 4320},
+	{id: 1, name: "LO", description: "Live Odds", code: "liveodds", scope: "live", recoveryWindow: 600},
 	{id: 3, name: "Ctrl", description: "Betradar Ctrl", code: "pre", scope: "prematch", recoveryWindow: 4320},
 	{id: 4, name: "BetPal", description: "BetPal", code: "betpal", scope: "live", recoveryWindow: 4320},
 	{id: 5, name: "PremiumCricket", description: "Premium Cricket", code: "premium_cricket", scope: "live|prematch", recoveryWindow: 4320},


### PR DESCRIPTION
SDK consumer failed. aborting...: NOTICE uof error op: recovery for liveodds, timestamp: 1697276221625, requestID: 1, inner: uof error op: http.StatusCode, inner: uof api error url: https://api.betradar.playexch.pvotal.internal:8443/v1/liveodds/recovery/initiate_request?after=1697276221625&request_id=1&node_id=11111, status code: 400, response: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><response response_code="BAD_REQUEST"><action>Request with id: 1 node id: 11111 for LO recovery from bookmaker: 38616 received</action><message>ERROR. Bad Request: Timestamp too far in the past! Allowed is max 10 hours in the past</message>