### PR TITLE
fix(pvo-1225): print full addr on dial error

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -10,7 +10,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/pvotal-tech/go-uof-sdk"
@@ -189,8 +188,7 @@ func dial(ctx context.Context, server string, bookmakerID int, token string, nod
 	}
 	conn, err := amqp.DialConfig(addr, config)
 	if err != nil {
-		fmt.Println(strings.ReplaceAll(addr, token, "<token>"))
-		return nil, uof.Notice("conn.Dial", err)
+		return nil, uof.Notice("conn.Dial", fmt.Errorf("%w (%s)", err, addr))
 	}
 
 	chnl, err := conn.Channel()


### PR DESCRIPTION
`ERRO[0005] SDK consumer failed error="NOTICE uof error op: conn.Dial, inner: Exception (403) Reason: \"username or password not allowed\" (amqps://123456789:@stgmq.betradar.com:5671//unifiedfeed/38616)" process=BetradarUnifiedFeed subject=system`