### PR TITLE
fix(pvo-1232): UTs catchup

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -23,7 +23,8 @@ const EnvToken = "UOF_TOKEN"
 // this test depends on UOF_TOKEN environment variable
 // to be set to the staging access token
 // run it as:
-//    UOF_TOKEN=my-token go test -v
+//
+//	UOF_TOKEN=my-token go test -v
 func TestIntegration(t *testing.T) {
 	token, ok := os.LookupEnv(EnvToken)
 	if !ok {
@@ -92,7 +93,7 @@ func testMarketVariant(t *testing.T, a *API) {
 
 func testFixture(t *testing.T, a *API) {
 	lang := uof.LangEN
-	f, err := a.Fixture(lang, "sr:match:8696826")
+	f, err := a.FixtureBytes(lang, "sr:match:8696826")
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, len(f))
 	assert.NotEqual(t, -1, bytes.Index(f, []byte("sr:match:8696826")))

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -67,7 +67,7 @@ func main() {
 		sdk.Credentials(123456, "token_goes_here", 123),
 		sdk.Staging(),
 		sdk.Recovery(pc),
-		sdk.ConfigThrottle(true),
+		sdk.ConfigThrottle(true, 0),
 		//sdk.Fixtures(preloadTo),
 		sdk.Languages(uof.Languages("en")),
 		//sdk.BufferedConsumer(pipe.FileStore("./tmp"), 1024),
@@ -89,7 +89,7 @@ func logMessages(in <-chan *uof.Message) error {
 
 func processMessage(m *uof.Message) {
 	var pendingCount, p, requestID, sport string
-	if m.External {
+	if m.Delivery != nil {
 		pendingCount = fmt.Sprintf("pending=%d", m.PendingMsgCount)
 		p = fmt.Sprintf("producer=%s", m.Producer.Code())
 		if m.Type == uof.MessageTypeBetSettlement {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/pvotal-tech/go-uof-sdk"
+	"github.com/pvotal-tech/go-uof-sdk/api"
 	"github.com/pvotal-tech/go-uof-sdk/sdk"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -54,102 +55,162 @@ func main() {
 	}()
 	go debugHTTP()
 
-	//preloadTo := time.Now().Add(24 * time.Hour)
+	//preloadTo := time.Now().Add(1 * time.Hour)
 
-	timestamp := uof.CurrentTimestamp() - 12*60*60*1000 // -5 minutes
-	var pc uof.ProducersChange
-	pc.Add(uof.ProducerPrematch, timestamp)
-	pc.Add(uof.ProducerLiveOdds, timestamp)
-	pc.Add(uof.ProducerBetPal, timestamp)
-	pc.Add(uof.ProducerPremiumCricket, timestamp)
+	timestamp := uof.CurrentTimestamp() - 1000 // -5 minutes
+	var ppp uof.ProducersChange
+	ppp.Add(uof.ProducerPrematch, timestamp)
+	//pc.Add(uof.ProducerLiveOdds, timestamp)
+	//pc.Add(uof.ProducerBetPal, timestamp)
+	//pc.Add(uof.ProducerPremiumCricket, timestamp)
 
 	err := sdk.Run(exitSignal(),
-		sdk.Credentials(123456, "token_goes_here", 123),
+		sdk.Credentials(38616, "j8l0CpSoytxhp7xb7r", 123456),
 		sdk.Staging(),
-		sdk.Recovery(pc),
-		sdk.ConfigThrottle(true),
+		//sdk.Recovery(ppp),
+		sdk.DisablePipeline(),
+		sdk.ConfigThrottle(false, 10),
+		//sdk.ConfigConcurrentAPIFetch(true),
+		sdk.DisableAutoAck(),
 		//sdk.Fixtures(preloadTo),
 		sdk.Languages(uof.Languages("en")),
 		//sdk.BufferedConsumer(pipe.FileStore("./tmp"), 1024),
 		sdk.Consumer(logMessages),
-		//sdk.ListenErrors(listenSDKErrors),
+		sdk.ListenErrors(listenSDKErrors),
 	)
 	if err != nil {
+		fmt.Println("SDK FAILED!!", err.Error())
 		log.Fatal(err)
 	}
+}
+
+func startReplay(rpl *api.ReplayAPI) error {
+	return nil
+	//return rpl.StartEvent(eventURN, speed, maxDelay)
+	//return rpl.StartScenario(scenarioID, speed, maxDelay)
 }
 
 // consumer of incoming messages
 func logMessages(in <-chan *uof.Message) error {
 	for m := range in {
-		processMessage(m)
+		err := processMessage(m)
+		if err != nil {
+			fmt.Println("error during message process, nacking and requesting requeue", err.Error())
+
+			if !m.EnabledAutoAck {
+				if err := m.NackRequeue(); err != nil {
+					fmt.Println("error during NackRequeue", err.Error())
+				}
+			}
+			continue
+		}
+		if !m.EnabledAutoAck {
+			if m.Delivery != nil {
+				fmt.Println("Acking", m.Delivery.DeliveryTag)
+			}
+			if err := m.Ack(); err != nil {
+				fmt.Println("error during Ack", err.Error())
+				continue
+			}
+		}
 	}
 	return nil
 }
 
-func processMessage(m *uof.Message) {
-	var pendingCount, p, requestID, sport string
-	if m.External {
-		pendingCount = fmt.Sprintf("pending=%d", m.PendingMsgCount)
-		p = fmt.Sprintf("producer=%s", m.Producer.Code())
-		if m.Type == uof.MessageTypeBetSettlement {
-			if m.BetSettlement.RequestID != nil {
-				requestID = fmt.Sprintf("requestID=%d", *m.BetSettlement.RequestID)
-			}
-			sport = fmt.Sprintf("sportID=%d", m.SportID)
-		}
-		if m.Type == uof.MessageTypeOddsChange {
-			if m.OddsChange.RequestID != nil {
-				requestID = fmt.Sprintf("requestID=%d", *m.OddsChange.RequestID)
-			}
-			sport = fmt.Sprintf("sportID=%d", m.SportID)
-		}
-	}
-	fmt.Printf("%-60s %-20s %-20s %-20s %-20s %-20s\n", time.Now().String(), m.Type, pendingCount, p, requestID, sport)
-	time.Sleep(time.Millisecond * 200)
-	return
+var sportMap = make(map[string]string)
+
+var errorCount int
+
+var pc uof.ProducersChange
+
+func processMessage(m *uof.Message) error {
+	time.Sleep(time.Second * 2000)
+	reqID := 0
+	fmt.Printf("%-25s | %-25v | %-25s | %-25d\n", m.Type, m.Delivery != nil, m.EventURN.String(), m.SportID)
+	return nil
 	switch m.Type {
 	case uof.MessageTypeConnection:
 		fmt.Printf("%-25s status: %s, server: %s, local: %s, network: %s, tls: %s\n", m.Type, m.Connection.Status, m.Connection.ServerName, m.Connection.LocalAddr, m.Connection.Network, m.Connection.TLSVersionToString())
 	case uof.MessageTypeFixture:
-		fmt.Printf("%-25s lang: %s, urn: %s raw: %d\n", m.Type, m.Lang, m.Fixture.URN, len(m.Raw))
+		//fmt.Printf("%-25s lang: %s, urn: %s raw: %d, timestamps %d\n", m.Type, m.Lang, m.FixtureBytes.URN, len(m.Raw), m.Timestamp)
 	case uof.MessageTypeMarkets:
-		fmt.Printf("%-25s lang: %s, count: %d\n", m.Type, m.Lang, len(m.Markets))
+		//fmt.Printf("%-25s lang: %s, count: %d\n", m.Type, m.Lang, len(m.Markets))
+	case uof.MessageTypePlayer:
+		//fmt.Printf("%-25s lang: %s, count: %d\n", m.Type, m.Lang, len(m.Markets))
 	case uof.MessageTypeAlive:
-		if m.Alive.Subscribed != 0 {
-			fmt.Printf("%-25s producer: %s, timestamp: %d\n", m.Type, m.Alive.Producer, m.Alive.Timestamp)
-		}
-	case uof.MessageTypeBetSettlement:
-		for _, v := range m.BetSettlement.Markets {
-			fmt.Printf("BET SETTLEMENT producer=%v eventID=%d marketID=%v status=%v\n", m.Producer, m.BetSettlement.EventURN.ID(), v.ID, v.Result)
-		}
-	case uof.MessageTypeBetStop:
-		for _, v := range m.BetStop.MarketIDs {
-			fmt.Printf("BET STOP producer=%v eventID=%d marketID=%v status=%v\n", m.Producer, m.BetStop.EventURN.ID(), v, m.BetStop.Status)
-		}
-	case uof.MessageTypeOddsChange:
-		fmt.Printf("ODDS CHANGE producer=%v eventID=%d eventStatus=%v\n", m.Producer, m.OddsChange.EventURN.ID(), m.OddsChange.EventStatus)
-		for _, v := range m.OddsChange.Markets {
-			fmt.Printf("ODDS CHANGE producer=%v eventID=%d marketID=%v status=%v\n", m.Producer, m.OddsChange.EventURN.ID(), v.ID, v.Status)
-		}
-	default:
-		var b []byte
-		if false && m.Raw != nil {
-			b = m.Raw
-			// remove xml header
-			if i := bytes.Index(b, []byte("?>")); i > 0 {
-				b = b[i+2:]
+		fmt.Printf("%-25s producer: %s, timestamp: %d, subscribed: %d, nodeID: %d\n", m.Type, m.Alive.Producer, m.Alive.Timestamp, m.Alive.Subscribed, m.NodeID)
+	case uof.MessageTypeSnapshotComplete:
+		fmt.Printf("%-25s prod: %s, reqID: %d, nodeID: %d\n", m.Type, m.SnapshotComplete.Producer, m.SnapshotComplete.RequestID, m.NodeID)
+	case uof.MessageTypeProducersChange:
+		statuses := make([]string, len(m.Producers))
+		for i, v := range m.Producers {
+			status := ""
+			switch v.Status {
+			case -1:
+				status = "down"
+			case 1:
+				status = "active"
+			case 2:
+				status = "in-recovery"
 			}
-		} else {
-			b, _ = json.Marshal(m.Body)
+			statuses[i] = v.Producer.Code() + "=" + status
 		}
-		// show just first x characters
-		x := 186
-		if len(b) > x {
-			b = b[:x]
-		}
-		fmt.Printf("%-25s %s\n", m.Type, b)
+		fmt.Printf("%-25s producers: %s \n", m.Type, strings.Join(statuses, "|"))
+	case uof.MessageTypeBetSettlement:
+		//if !validEventURN(m.BetSettlement.EventURN) { return nil }
+		if validRequestID(m.BetSettlement.RequestID) {
+			reqID = *m.BetSettlement.RequestID
+		} //return nil }
+		fmt.Println(m.Type, m.Delivery.DeliveryTag, m.NodeID, reqID)
+		//logObject(*m.BetSettlement)
+	case uof.MessageTypeRollbackBetSettlement:
+		//if !validEventURN(m.RollbackBetSettlement.EventURN) { return nil }
+		if validRequestID(m.RollbackBetSettlement.RequestID) {
+			reqID = *m.RollbackBetSettlement.RequestID
+		} //return nil }
+		fmt.Println(m.Type, m.Delivery.DeliveryTag, m.NodeID, reqID)
+		//logObject(*m.RollbackBetSettlement)
+	case uof.MessageTypeBetStop:
+		//if !validEventURN(m.BetStop.EventURN) { return nil }
+		if validRequestID(m.BetStop.RequestID) {
+			reqID = *m.BetStop.RequestID
+		} //return nil }
+		fmt.Println(m.Type, m.Delivery.DeliveryTag, m.NodeID, reqID)
+		//logObject(*m.BetStop)
+	case uof.MessageTypeBetCancel:
+		//if !validEventURN(m.BetCancel.EventURN) { return nil }
+		if validRequestID(m.BetCancel.RequestID) {
+			reqID = *m.BetCancel.RequestID
+		} //return nil }
+		fmt.Println(m.Type, m.Delivery.DeliveryTag, m.NodeID, reqID)
+		//logObject(*m.BetCancel)
+	case uof.MessageTypeRollbackBetCancel:
+		//if !validEventURN(m.RollbackBetCancel.EventURN) { return nil }
+		if validRequestID(m.RollbackBetCancel.RequestID) {
+			reqID = *m.RollbackBetCancel.RequestID
+		} //return nil }
+		fmt.Println(m.Type, m.Delivery.DeliveryTag, m.NodeID, reqID)
+		//logObject(*m.RollbackBetCancel)
+	case uof.MessageTypeOddsChange:
+		//if !validEventURN(m.OddsChange.EventURN) { return nil }
+		if validRequestID(m.OddsChange.RequestID) {
+			reqID = *m.OddsChange.RequestID
+		} //return nil }
+		fmt.Println(m.Type, m.Delivery.DeliveryTag, m.NodeID, reqID)
+		//logObject(*m.OddsChange)
 	}
+	return nil
+}
+
+func validRequestID(requestID *int) bool {
+	if requestID == nil {
+		return false
+	}
+	return true //*requestID == 999999
+}
+
+func validEventURN(urn uof.URN) bool {
+	return urn.ID() == 41763059
 }
 
 // listenSDKErrors listens all SDK errors for logging or any other pourpose
@@ -191,4 +252,21 @@ func listenSDKErrors(err error) {
 		// any other error not uof.Error
 		log.Println(err)
 	}
+}
+
+func logObject(obj interface{}) {
+	bytes, err := json.MarshalIndent(obj, "", " ")
+	if err != nil {
+		fmt.Println("ERROR WHILE UNMARSHALLING")
+	}
+	fmt.Println(string(bytes))
+}
+
+func getProducerChange(producers uof.ProducersChange, producer uof.Producer) (*uof.ProducerChange, error) {
+	for _, p := range producers {
+		if p.Producer.Code() == producer.Code() {
+			return &p, nil
+		}
+	}
+	return nil, fmt.Errorf("invalid producer: %s (forgot to do recovery?)", producer.Code())
 }

--- a/message_test.go
+++ b/message_test.go
@@ -141,9 +141,9 @@ func TestMessageWithRawMarshal(t *testing.T) {
 	}
 
 	buf := m.Marshal()
-	expected := []byte(`{"type":64,"scope":4,"receivedAt":12345,"producer":3,"timestamp":12340}
+	expected := []byte(`{"type":64,"scope":4,"receivedAt":12345,"producer":3,"timestamp":12340,"Delivery":null,"EnabledAutoAck":false,"ReadAt":"0001-01-01T00:00:00Z"}
 <alive product="3" timestamp="12340" subscribed="1"/>`)
-	assert.Equal(t, expected, buf)
+	assert.Equal(t, string(expected), string(buf))
 
 	m2 := &Message{}
 	err := m2.Unmarshal(buf)
@@ -162,8 +162,8 @@ func TestMessageWithoutRaw(t *testing.T) {
 	}
 
 	buf := m.Marshal()
-	expected := []byte(`{"type":66,"scope":4,"receivedAt":12345,"connection":{"status":1}}`)
-	assert.Equal(t, expected, buf)
+	expected := []byte(`{"type":66,"scope":4,"receivedAt":12345,"Delivery":null,"EnabledAutoAck":false,"ReadAt":"0001-01-01T00:00:00Z","connection":{"status":1}}`)
+	assert.Equal(t, string(expected), string(buf))
 
 	m2 := &Message{}
 	err := m2.Unmarshal(buf)
@@ -270,7 +270,7 @@ func TestNewMessage(t *testing.T) {
 
 func TestNewMessageFromBufFail(t *testing.T) {
 	failing := []byte{}
-	expectErr := fmt.Errorf("NOTICE uof error op: message.unpack, inner: EOF")
+	expectErr := fmt.Errorf("NOTICE uof error op: message.unpack, inner: EOF:")
 	m, err := NewFixtureMessageFromBuf(LangEN, failing, 0)
 	assert.Nil(t, m)
 	assert.Error(t, err)
@@ -285,7 +285,7 @@ func TestUnpackFail(t *testing.T) {
 
 	_, err := NewQueueMessage("hi.pre.-.bet_cancel.1.sr:match.1234.-", buf)
 	assert.Error(t, err)
-	assert.Equal(t, `NOTICE uof error op: message.unpack, inner: strconv.ParseInt: parsing "int": invalid syntax`, err.Error())
+	assert.Equal(t, `NOTICE uof error op: message.unpack, inner: strconv.ParseInt: parsing "int": invalid syntax`+":"+string(buf), err.Error())
 
 	// height should be int
 	buf = []byte(`
@@ -295,7 +295,7 @@ func TestUnpackFail(t *testing.T) {
 	`)
 	_, err = NewAPIMessage(LangEN, MessageTypePlayer, buf)
 	assert.Error(t, err)
-	assert.Equal(t, `NOTICE uof error op: message.unpack, inner: strconv.ParseInt: parsing "int": invalid syntax`, err.Error())
+	assert.Equal(t, `NOTICE uof error op: message.unpack, inner: strconv.ParseInt: parsing "int": invalid syntax`+":"+string(buf), err.Error())
 
 	var m Message
 	err = m.Unmarshal(nil)

--- a/pipe/fixture_test.go
+++ b/pipe/fixture_test.go
@@ -13,11 +13,22 @@ type fixtureAPIMock struct {
 	preloadTo time.Time
 	eventURN  uof.URN
 	//requests map[int]struct{}
+	date string
 	sync.Mutex
 }
 
-func (m *fixtureAPIMock) Fixture(lang uof.Lang, eventURN uof.URN) ([]byte, error) {
+func (m *fixtureAPIMock) Fixture(lang uof.Lang, eventURN uof.URN) (uof.Fixture, error) {
 	m.eventURN = eventURN
+	return uof.Fixture{}, nil
+}
+
+func (m *fixtureAPIMock) FixtureBytes(lang uof.Lang, eventURN uof.URN) ([]byte, error) {
+	m.eventURN = eventURN
+	return nil, nil
+}
+
+func (m *fixtureAPIMock) DailySchedule(lang uof.Lang, date string) ([]uof.Fixture, error) {
+	m.date = date
 	return nil, nil
 }
 
@@ -35,7 +46,7 @@ func (m *fixtureAPIMock) Fixtures(lang uof.Lang, to time.Time) (<-chan uof.Fixtu
 func TestFixturePipe(t *testing.T) {
 	a := &fixtureAPIMock{}
 	preloadTo := time.Now().Add(time.Hour)
-	f := Fixture(a, []uof.Lang{uof.LangEN, uof.LangDE}, preloadTo)
+	f := Fixture(a, []uof.Lang{uof.LangEN}, preloadTo)
 	assert.NotNil(t, f)
 
 	in := make(chan *uof.Message)
@@ -50,6 +61,7 @@ func TestFixturePipe(t *testing.T) {
 	m = fixtureChangeMsg(t)
 	in <- m
 	om = <-out
+	om = <-out // second message is the fixture
 	assert.Equal(t, m, om)
 
 	close(in)

--- a/pipe/player_test.go
+++ b/pipe/player_test.go
@@ -23,30 +23,26 @@ func (m *playerAPIMock) Player(lang uof.Lang, playerID int) (*uof.Player, error)
 
 func TestPlayerPipe(t *testing.T) {
 	a := &playerAPIMock{requests: make(map[int]struct{})}
-	p := Player(a, []uof.Lang{uof.LangEN, uof.LangDE})
+	p := Player(a, []uof.Lang{uof.LangEN}, false)
 	assert.NotNil(t, p)
 
 	in := make(chan *uof.Message)
 	out, _ := p(in)
 
-	// this type of message is passing through
-	m := uof.NewSimpleConnnectionMessage(uof.ConnectionStatusUp)
+	m := oddsChangeMessage(t)
 	in <- m
-	om := <-out
-	assert.Equal(t, m, om)
-
-	m = oddsChangeMessage(t)
-	in <- m
-	om = <-out
-	assert.Equal(t, m, om)
 
 	close(in)
 	cnt := 0
-	for range out {
-		cnt++
+	for om := range out {
+		if om.Type == uof.MessageTypeOddsChange {
+			assert.Equal(t, m, om)
+		} else {
+			cnt++
+		}
 	}
-	assert.Equal(t, 82, cnt)
-	assert.Equal(t, 82, len(a.requests))
+	assert.Equal(t, 41, cnt)
+	assert.Equal(t, 41, len(a.requests))
 }
 
 func oddsChangeMessage(t *testing.T) *uof.Message {

--- a/pipe/recovery_test.go
+++ b/pipe/recovery_test.go
@@ -11,17 +11,19 @@ type requestRecoveryParams struct {
 	producer  uof.Producer
 	timestamp int
 	requestID int
+	nodeID    int
 }
 
 type recoveryAPIMock struct {
 	calls chan requestRecoveryParams
 }
 
-func (m *recoveryAPIMock) RequestRecovery(producer uof.Producer, timestamp int, requestID int) error {
+func (m *recoveryAPIMock) RequestRecovery(producer uof.Producer, timestamp int, requestID int, nodeID int) error {
 	m.calls <- requestRecoveryParams{
 		producer:  producer,
 		timestamp: timestamp,
 		requestID: requestID,
+		nodeID:    nodeID,
 	}
 	return nil
 }
@@ -46,7 +48,7 @@ func TestRecoveryStateMachine(t *testing.T) {
 	ps.Add(uof.ProducerPrematch, timestamp)
 	ps.Add(uof.ProducerLiveOdds, timestamp+1)
 	m := &recoveryAPIMock{calls: make(chan requestRecoveryParams, 16)}
-	r := newRecovery(m, ps)
+	r := newRecovery(m, ps, 0)
 
 	// 0. initilay all producers are down
 	for _, p := range r.producers {
@@ -118,7 +120,7 @@ func TestRecoveryRequests(t *testing.T) {
 	ps.Add(uof.ProducerLiveOdds, timestamp+1)
 
 	m := &recoveryAPIMock{calls: make(chan requestRecoveryParams, 16)}
-	r := newRecovery(m, ps)
+	r := newRecovery(m, ps, 0)
 	in := make(chan *uof.Message)
 	out := make(chan *uof.Message, 16)
 	errc := make(chan error, 16)

--- a/speficiers_test.go
+++ b/speficiers_test.go
@@ -1,17 +1,13 @@
 package uof
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestParseNameWithSpecifiers(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	players := NewMapCache[int, Player](ctx, time.Hour, time.Hour)
-	players.Set(1234, Player{FullName: "John Rodriquez"})
+	players := map[int]Player{1234: {FullName: "John Rodriquez"}}
 	fixture := Fixture{
 		Name: "Euro2016",
 		Competitors: []Competitor{
@@ -147,5 +143,4 @@ func TestParseNameWithSpecifiers(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
-	cancel()
 }


### PR DESCRIPTION
```
GOROOT=/opt/homebrew/Cellar/go/1.20.6/libexec #gosetup
GOPATH=/Users/guillermomugnaini/go #gosetup
/opt/homebrew/Cellar/go/1.20.6/libexec/bin/go test -json ./...
{"Time":"2024-01-04T15:58:22.705568-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk"}
=== RUN   TestProducer
--- PASS: TestProducer (0.00s)
=== RUN   TestURN
--- PASS: TestURN (0.00s)
{"Time":"2024-01-04T15:58:22.705676-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk/api"}
=== RUN   TestTemplate
=== RUN   TestLanguage
--- PASS: TestTemplate (0.00s)
=== RUN   TestIntegration
--- PASS: TestLanguage (0.00s)
    api_test.go:31: integration token not found
--- SKIP: TestIntegration (0.00s)

Test ignored.
=== RUN   TestBetCancelSeedData
    api_test.go:54: skipping test; $seed_data env not set
--- SKIP: TestBetCancelSeedData (0.00s)

Test ignored.
=== RUN   TestMessageTypes
PASS
--- PASS: TestMessageTypes (0.00s)
ok  	github.com/pvotal-tech/go-uof-sdk/api	(cached)
=== RUN   TestURNEventID
--- PASS: TestURNEventID (0.00s)
=== RUN   TestProducersChange
--- PASS: TestProducersChange (0.00s)
=== RUN   TestError
--- PASS: TestError (0.00s)
=== RUN   TestInnerError
--- PASS: TestInnerError (0.00s)
=== RUN   TestMessageParseRoutingKeys
--- PASS: TestMessageParseRoutingKeys (0.00s)
=== RUN   TestMessageTypeParse
--- PASS: TestMessageTypeParse (0.00s)
=== RUN   TestMessageWithRawMarshal
--- PASS: TestMessageWithRawMarshal (0.00s)
=== RUN   TestMessageWithoutRaw
--- PASS: TestMessageWithoutRaw (0.00s)
=== RUN   TestUID
--- PASS: TestUID (0.00s)
=== RUN   TestUIDWithLang
--- PASS: TestUIDWithLang (0.00s)
=== RUN   TestNewMessage
--- PASS: TestNewMessage (0.00s)
=== RUN   TestNewMessageFromBufFail
--- PASS: TestNewMessageFromBufFail (0.00s)
=== RUN   TestUnpackFail
--- PASS: TestUnpackFail (0.00s)
=== RUN   TestEnrichHeaderAfterUnpack
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: snapshot_complete 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: alive 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: fixture_change 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: bet_stop 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: odds_change 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: bet_settlement 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: rollback_bet_settlement 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: bet_cancel 
    message_test.go:434: prod: liveodds ts: 1234578910111 msg type: rollback_bet_cancel 
--- PASS: TestEnrichHeaderAfterUnpack (0.00s)
=== RUN   TestOddsChange
=== RUN   TestOddsChange/unmarshal
--- PASS: TestOddsChange/unmarshal (0.00s)
=== RUN   TestOddsChange/status
--- PASS: TestOddsChange/status (0.00s)
=== RUN   TestOddsChange/urn
--- PASS: TestOddsChange/urn (0.00s)
=== RUN   TestOddsChange/specifier
--- PASS: TestOddsChange/specifier (0.00s)
=== RUN   TestOddsChange/marketStatus
--- PASS: TestOddsChange/marketStatus (0.00s)
=== RUN   TestOddsChange/eachPlayer
--- PASS: TestOddsChange/eachPlayer (0.00s)
=== RUN   TestOddsChange/eachVariantMerket
--- PASS: TestOddsChange/eachVariantMerket (0.00s)
--- PASS: TestOddsChange (0.00s)
=== RUN   TestSpecifiersParsing
--- PASS: TestSpecifiersParsing (0.00s)
=== RUN   TestNilMethodCalls
--- PASS: TestNilMethodCalls (0.00s)
=== RUN   TestBetCancel
--- PASS: TestBetCancel (0.00s)
=== RUN   TestRollbackBetCancel
--- PASS: TestRollbackBetCancel (0.00s)
=== RUN   TestBetSettlement
--- PASS: TestBetSettlement (0.00s)
=== RUN   TestRollbackBetSettlement
--- PASS: TestRollbackBetSettlement (0.00s)
=== RUN   TestBetStop
--- PASS: TestBetStop (0.00s)
=== RUN   TestFixtureChange
--- PASS: TestFixtureChange (0.00s)
=== RUN   TestSnaphotComplete
--- PASS: TestSnaphotComplete (0.00s)
=== RUN   TestMarkets
--- PASS: TestMarkets (0.00s)
=== RUN   TestPlayerMale
--- PASS: TestPlayerMale (0.00s)
=== RUN   TestPlayerFemale
--- PASS: TestPlayerFemale (0.00s)
=== RUN   TestPlayerUnknown
--- PASS: TestPlayerUnknown (0.00s)
=== RUN   TestFixture
--- PASS: TestFixture (0.00s)
=== RUN   TestFixutreWithPlayers
--- PASS: TestFixutreWithPlayers (0.00s)
=== RUN   TestFixtureNoTournament
--- PASS: TestFixtureNoTournament (0.00s)
=== RUN   TestBetSettlementToResult
--- PASS: TestBetSettlementToResult (0.00s)
=== RUN   TestBetStopToMarketStatus
--- PASS: TestBetStopToMarketStatus (0.00s)
=== RUN   TestToOutcomeType
--- PASS: TestToOutcomeType (0.00s)
=== RUN   TestToSpecifierType
--- PASS: TestToSpecifierType (0.00s)
=== RUN   TestConnectionStatus
--- PASS: TestConnectionStatus (0.00s)
=== RUN   TestParseNameWithSpecifiers
=== RUN   TestParseNameWithSpecifiers/Replace_{X}_with_value_of_specifier
--- PASS: TestParseNameWithSpecifiers/Replace_{X}_with_value_of_specifier (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{!X}_with_the_ordinal_value_of_specifier_X
--- PASS: TestParseNameWithSpecifiers/Replace_{!X}_with_the_ordinal_value_of_specifier_X (0.00s)
=== RUN   TestParseNameWithSpecifiers/(-)_Replace_{X+/-c}_with_the_value_of_the_specifier_X_+_or_-_the_number_c
--- PASS: TestParseNameWithSpecifiers/(-)_Replace_{X+/-c}_with_the_value_of_the_specifier_X_+_or_-_the_number_c (0.00s)
=== RUN   TestParseNameWithSpecifiers/(+)_Replace_{X+/-c}_with_the_value_of_the_specifier_X_+_or_-_the_number_c
--- PASS: TestParseNameWithSpecifiers/(+)_Replace_{X+/-c}_with_the_value_of_the_specifier_X_+_or_-_the_number_c (0.00s)
=== RUN   TestParseNameWithSpecifiers/(-)_Replace_{!X+c}_with_the_ordinal_value_of_specifier_X_+_c
--- PASS: TestParseNameWithSpecifiers/(-)_Replace_{!X+c}_with_the_ordinal_value_of_specifier_X_+_c (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{!X+c}_with_the_ordinal_value_of_specifier_X_+_c
--- PASS: TestParseNameWithSpecifiers/Replace_{!X+c}_with_the_ordinal_value_of_specifier_X_+_c (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{+X}_with_the_value_of_specifier_X_with_a_+/-_sign_in_front
--- PASS: TestParseNameWithSpecifiers/Replace_{+X}_with_the_value_of_specifier_X_with_a_+/-_sign_in_front (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{-X}_with_the_negated_value_of_the_specifier_with_a_+/-_sign_in_front
--- PASS: TestParseNameWithSpecifiers/Replace_{-X}_with_the_negated_value_of_the_specifier_with_a_+/-_sign_in_front (0.00s)
=== RUN   TestParseNameWithSpecifiers/Name_with_2_normal_specifiers
--- PASS: TestParseNameWithSpecifiers/Name_with_2_normal_specifiers (0.00s)
=== RUN   TestParseNameWithSpecifiers/Name_with_1_normal,_1_ordinal_specifier
--- PASS: TestParseNameWithSpecifiers/Name_with_1_normal,_1_ordinal_specifier (0.00s)
=== RUN   TestParseNameWithSpecifiers/Name_with_1_ordinal,_1_+/-_specifier
--- PASS: TestParseNameWithSpecifiers/Name_with_1_ordinal,_1_+/-_specifier (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{%player}_with_name_of_specifier
--- PASS: TestParseNameWithSpecifiers/Replace_{%player}_with_name_of_specifier (0.00s)
=== RUN   TestParseNameWithSpecifiers/Player_with_1_normal,_1_ordinal_specifier
--- PASS: TestParseNameWithSpecifiers/Player_with_1_normal,_1_ordinal_specifier (0.00s)
=== RUN   TestParseNameWithSpecifiers/Market_ID_368
--- PASS: TestParseNameWithSpecifiers/Market_ID_368 (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{$event}_with_the_name_of_the_event
--- PASS: TestParseNameWithSpecifiers/Replace_{$event}_with_the_name_of_the_event (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{$competitorN}_with_the_Nth_competitor_in_the_event_(empty_map)
--- PASS: TestParseNameWithSpecifiers/Replace_{$competitorN}_with_the_Nth_competitor_in_the_event_(empty_map) (0.00s)
=== RUN   TestParseNameWithSpecifiers/Replace_{X}_with_value_of_specifier_for_decimals
--- PASS: TestParseNameWithSpecifiers/Replace_{X}_with_value_of_specifier_for_decimals (0.00s)
=== RUN   TestParseNameWithSpecifiers/2_Competitor_with_corners
--- PASS: TestParseNameWithSpecifiers/2_Competitor_with_corners (0.00s)
--- PASS: TestParseNameWithSpecifiers (0.00s)
PASS
ok  	github.com/pvotal-tech/go-uof-sdk	(cached)
{"Time":"2024-01-04T15:58:22.728744-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk/cmd/client"}
?   	github.com/pvotal-tech/go-uof-sdk/cmd/client	[no test files]
{"Time":"2024-01-04T15:58:22.728795-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk/cmd/replay"}
?   	github.com/pvotal-tech/go-uof-sdk/cmd/replay	[no test files]
{"Time":"2024-01-04T15:58:22.728853-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk/pipe"}
=== RUN   TestBetStop
--- PASS: TestBetStop (0.00s)
=== RUN   TestDedup
--- PASS: TestDedup (0.00s)
{"Time":"2024-01-04T15:58:22.72888-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk/queue"}
=== RUN   TestFixturePipe
--- PASS: TestFixturePipe (0.00s)
=== RUN   TestMarketsPipe
--- PASS: TestMarketsPipe (0.00s)
=== RUN   TestExpireMap
--- PASS: TestExpireMap (0.00s)
=== RUN   TestPlayerPipe
--- PASS: TestPlayerPipe (0.00s)
=== RUN   TestRecoveryTimestamp
?   	github.com/pvotal-tech/go-uof-sdk/queue	[no test files]
{"Time":"2024-01-04T15:58:22.729144-03:00","Action":"start","Package":"github.com/pvotal-tech/go-uof-sdk/sdk"}
?   	github.com/pvotal-tech/go-uof-sdk/sdk	[no test files]
--- PASS: TestRecoveryTimestamp (0.00s)
=== RUN   TestRecoveryStateMachine
--- PASS: TestRecoveryStateMachine (0.00s)
=== RUN   TestRecoveryRequests
--- PASS: TestRecoveryRequests (0.00s)
PASS
ok  	github.com/pvotal-tech/go-uof-sdk/pipe	(cached)

Process finished with the exit code 0
```